### PR TITLE
make the layout mobile only

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,12 +1,19 @@
-import { AppSidebar } from "~/components/app-sidebar";
-import { Separator } from "~/components/ui/separator";
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from "~/components/ui/sidebar";
+// import { AppSidebar } from "~/components/app-sidebar";
+// import { Separator } from "~/components/ui/separator";
+// import {
+//   SidebarInset,
+//   SidebarProvider,
+//   SidebarTrigger,
+// } from "~/components/ui/sidebar";
 
-export default function Page() {
+export default function DashboardPage() {
+
+  return (
+    <div>
+      <h1>Dashboard WIP</h1>
+    </div>
+  );
+  /*
   return (
     <SidebarProvider>
       <AppSidebar />
@@ -31,4 +38,5 @@ export default function Page() {
       </SidebarInset>
     </SidebarProvider>
   );
+*/
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import Sidebar from "~/components/sidebar";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <Sidebar>
-      <main className="flex-1 p-4 lg:p-6">{children}</main>
+      <main className="flex-1">{children}</main>
     </Sidebar>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,21 +5,10 @@ import {
   SignedOut,
   SignInButton,
   SignUpButton,
-  useAuth,
 } from "@clerk/nextjs";
-import { useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 export default function LandingPage() {
-  const { isSignedIn } = useAuth();
-  const router = useRouter();
-
-  // useEffect(() => {
-  //   if (isSignedIn) {
-  //     router.replace("/transactions");
-  //   }
-  // }, [isSignedIn, router]);
 
   return (
     <div className="mx-auto max-w-screen-sm space-y-10 p-6">
@@ -84,7 +73,7 @@ export default function LandingPage() {
 
 function BadgeCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-card rounded-lg border p-3 text-sm shadow-sm">
+    <div className="bg-card rounded-lg border p-3 text-sm shadow-sm text-center">
       {children}
     </div>
   );

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -16,34 +16,36 @@ import { Sidebar, SidebarContent, SidebarRail } from "~/components/ui/sidebar";
 // TODO: Replace with actual user data
 // TODO: Replace navigation with actual pages
 // TODO: Remove projects Section
+export const NAV_ITEMS = [
+  {
+    title: "Overview",
+    url: "/dashboard",
+    icon: DollarSign,
+  },
+  {
+    title: "Transactions",
+    url: "/transactions",
+    icon: CreditCard,
+  },
+  {
+    title: "Budgets",
+    url: "/budgets",
+    icon: PieChart,
+  },
+  {
+    title: "Goals",
+    url: "/goals",
+    icon: PiggyBank,
+  },
+  {
+    title: "Accounts",
+    url: "/accounts",
+    icon: Banknote,
+  },
+];
+
 const data = {
-  navMain: [
-    {
-      title: "Overview",
-      url: "/",
-      icon: DollarSign,
-    },
-    {
-      title: "Transactions",
-      url: "/transactions",
-      icon: CreditCard,
-    },
-    {
-      title: "Budgets",
-      url: "/budgets",
-      icon: PieChart,
-    },
-    {
-      title: "Goals",
-      url: "/goals",
-      icon: PiggyBank,
-    },
-    {
-      title: "Accounts",
-      url: "/accounts",
-      icon: Banknote,
-    },
-  ],
+  navMain: NAV_ITEMS,
 };
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {

--- a/src/components/bottom-nav.module.css
+++ b/src/components/bottom-nav.module.css
@@ -1,0 +1,33 @@
+/* Top border line with centered circular notch for FAB */
+.notch {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 32px; /* controls notch depth area */
+  pointer-events: none;
+}
+
+.notch::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 1px;
+  background: hsl(var(--border));
+}
+
+.notch::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;           /* notch diameter (>= FAB size) */
+  height: 64px;
+  top: -32px;            /* -0.5 * diameter */
+  border: 1px solid hsl(var(--border));
+  border-radius: 9999px;
+  background: hsl(var(--background));
+  /* Show only the lower half to create the dip */
+  clip-path: inset(50% 0 0 0);
+} 

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NAV_ITEMS } from "~/components/app-sidebar";
+import { cn } from "~/lib/utils";
+import styles from "./bottom-nav.module.css";
+
+export default function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/90 shadow-[0_-4px_12px_rgba(0,0,0,0.04)] backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <div className={styles.notch} />
+      <ul className="relative z-10 mx-auto grid max-w-screen-md grid-cols-5 items-center gap-1 px-3 py-2 md:max-w-screen-sm">
+        {NAV_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname === item.url || (item.url !== "/" && pathname?.startsWith(item.url));
+          return (
+            <li key={item.title} className="flex items-center justify-center">
+              <Link
+                href={item.url}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground group flex w-full flex-col items-center justify-center gap-1 rounded-md px-3 py-2 text-[11px] font-medium md:text-xs",
+                  isActive && "text-foreground"
+                )}
+              >
+                {Icon && (
+                  <Icon className={cn("h-5 w-5", isActive ? "opacity-100" : "opacity-70")} />
+                )}
+                <span className="leading-none">{item.title}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+} 

--- a/src/components/quick-add-fab.tsx
+++ b/src/components/quick-add-fab.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { Input } from "~/components/ui/input";
+import { useMutation } from "convex/react";
+import { api } from "convex/_generated/api";
+
+export default function QuickAddFab() {
+  const [open, setOpen] = useState(false);
+  const [amount, setAmount] = useState("");
+  const [merchant, setMerchant] = useState("");
+  const createTransaction = useMutation(api.transactions.createTransaction);
+
+  const onQuickSave = async () => {
+    const parsedAmount = parseFloat(amount);
+    if (!parsedAmount || parsedAmount <= 0) return;
+    await createTransaction({
+      merchantName: merchant || undefined,
+      description: undefined,
+      amount: parsedAmount,
+      type: "expense",
+      category: undefined,
+      date: new Date().toISOString(),
+    });
+    setOpen(false);
+    setAmount("");
+    setMerchant("");
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-x-0 bottom-16 z-50 flex justify-center"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 8px)" }}
+      >
+        <Button
+          aria-label="Quick add transaction"
+          size="icon"
+          className="h-14 w-14 rounded-full shadow-lg"
+          onClick={() => setOpen(true)}
+        >
+          <Plus className="h-6 w-6" />
+        </Button>
+      </div>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="bottom" className="space-y-4">
+          <SheetHeader>
+            <SheetTitle>Quick Add</SheetTitle>
+          </SheetHeader>
+          <div className="flex gap-3">
+            <Input
+              inputMode="decimal"
+              placeholder="Amount"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
+            <Input
+              placeholder="Merchant (optional)"
+              value={merchant}
+              onChange={(e) => setMerchant(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={onQuickSave}>Save</Button>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+} 

--- a/src/components/recent-transactions.tsx
+++ b/src/components/recent-transactions.tsx
@@ -19,10 +19,22 @@ interface RecentTransactionsProps {
   showAll?: boolean;
 }
 
+type Transaction = {
+  id: string;
+  date: string;
+  merchant: string;
+  description: string;
+  amount: number;
+  type: string;
+  category: string;
+};
+
 export function RecentTransactions({
   showAll = false,
 }: RecentTransactionsProps) {
-  const [transactions, setTransactions] = useState(mockTransactions);
+  const [transactions, setTransactions] = useState<Transaction[]>(
+    mockTransactions as Transaction[],
+  );
   const [searchTerm, setSearchTerm] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
 
@@ -48,11 +60,12 @@ export function RecentTransactions({
     setTransactions(transactions.filter((t) => t.id !== id));
   };
 
-  const handleEditTransaction = (id: string, updatedTransaction: any) => {
+  const handleEditTransaction = (
+    id: string,
+    updatedTransaction: Partial<Transaction>,
+  ) => {
     setTransactions(
-      transactions.map((t) =>
-        t.id === id ? { ...t, ...updatedTransaction } : t,
-      ),
+      transactions.map((t) => (t.id === id ? { ...t, ...updatedTransaction } : t)),
     );
   };
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,24 +1,28 @@
-import { AppSidebar } from "~/components/app-sidebar";
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from "~/components/ui/sidebar";
 import { UserButton } from "@clerk/nextjs";
+import BottomNav from "~/components/bottom-nav";
+import QuickAddFab from "~/components/quick-add-fab";
 
 export default function Sidebar({ children }: { children: React.ReactNode }) {
   return (
-    <SidebarProvider defaultOpen={true} className="h-screen">
-      <AppSidebar />
-      <SidebarInset>
-        <header className="bg-accent sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-          <div className="flex w-full items-center justify-between gap-2 px-4">
-            <SidebarTrigger className="-ml-1" />
-            <UserButton />
-          </div>
-        </header>
-        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">{children}</div>
-      </SidebarInset>
-    </SidebarProvider>
+    <div className="relative min-h-dvh flex flex-col">
+      {/* Floating User Button respecting safe area top */}
+      <div
+        className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-end px-4"
+        style={{ paddingTop: "env(safe-area-inset-top)" }}
+      >
+        <div className="pointer-events-auto py-2">
+          <UserButton />
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 p-4 pt-2 pb-28">{children}</div>
+
+      {/* Quick Add floating action button */}
+      <QuickAddFab />
+
+      {/* Bottom navigation */}
+      <BottomNav />
+    </div>
   );
 }

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -46,7 +46,7 @@ interface TransactionItemProps {
     category: string;
   };
   onDelete: (id: string) => void;
-  onEdit: (id: string, updatedTransaction: any) => void;
+  onEdit: (id: string, updatedTransaction: Partial<TransactionItemProps["transaction"]>) => void;
 }
 
 export function TransactionItem({

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -45,7 +45,7 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = (asChild ? Slot : "button") as React.ElementType;
 
   return (
     <Comp

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -398,7 +398,7 @@ function SidebarGroupLabel({
   asChild = false,
   ...props
 }: React.ComponentProps<"div"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "div";
+  const Comp = (asChild ? Slot : "div") as React.ElementType;
 
   return (
     <Comp
@@ -419,7 +419,7 @@ function SidebarGroupAction({
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = (asChild ? Slot : "button") as React.ElementType;
 
   return (
     <Comp
@@ -508,7 +508,7 @@ function SidebarMenuButton({
   isActive?: boolean;
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = (asChild ? Slot : "button") as React.ElementType;
   const { isMobile, state } = useSidebar();
 
   const button = (
@@ -554,7 +554,7 @@ function SidebarMenuAction({
   asChild?: boolean;
   showOnHover?: boolean;
 }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = (asChild ? Slot : "button") as React.ElementType;
 
   return (
     <Comp
@@ -677,7 +677,7 @@ function SidebarMenuSubButton({
   size?: "sm" | "md";
   isActive?: boolean;
 }) {
-  const Comp = asChild ? Slot : "a";
+  const Comp = (asChild ? Slot : "a") as React.ElementType;
 
   return (
     <Comp


### PR DESCRIPTION
# 🚀 Mobile-first UI with Bottom Navigation and Quick Add FAB

## 📖 Context
- Redesigns the app layout for a mobile-first experience
- Improves usability on small screens with easy access to key navigation and quick transaction entry

## 🛠️ What's inside
- Added bottom navigation bar with notched design for mobile devices
- Created Quick Add FAB (Floating Action Button) for fast transaction entry
- Simplified dashboard page temporarily while mobile UI is being implemented
- Extracted navigation items to a shared constant for reuse
- Adjusted layout spacing and fixed header positioning for mobile
- Added safe area insets for iOS devices

## ✅ Checklist
- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm run dev
# Test on mobile devices and desktop browsers
# Test iOS safe areas using Safari dev tools
```

## 📸 Proof
<!-- Mobile screenshot showing bottom nav and FAB would go here -->

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- Start with the new bottom-nav component and quick-add-fab
- The dashboard page is temporarily simplified - will be rebuilt in a future PR
- Type safety improvements were made to several components