### PR TITLE
fix ios onlongpress implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
   "ct3aMetadata": {
     "initVersion": "7.39.3"
   },
-  "packageManager": "pnpm@10.12.4"
+  "packageManager": "pnpm@10.14.0"
 }

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -38,6 +38,7 @@ export default function BottomNav() {
                 <Link
                   href={item.url}
                   {...centerLongPress()}
+                  onContextMenu={(e) => e.preventDefault()}
                   className={cn(
                     "text-muted-foreground hover:text-foreground group relative flex w-full flex-col items-center justify-center gap-1 rounded-md px-3 py-2 text-[11px] font-medium md:text-xs",
                     isActive && "text-foreground",


### PR DESCRIPTION
# 🚀 Prevent context menu on bottom navigation & update pnpm

## 📖 Context
- Prevents the default context menu from appearing when right-clicking on bottom navigation links
- Updates pnpm package manager from 10.12.4 to 10.14.0

## 🛠️ What's inside
- Added `onContextMenu={(e) => e.preventDefault()}` to bottom navigation links to disable the default context menu
- Updated pnpm package manager version to 10.14.0

## ✅ Checklist
- [x] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [x] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
pnpm install
pnpm run dev
# Right-click on bottom navigation links to verify context menu doesn't appear
```

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- The context menu prevention is particularly important for mobile-like experiences where right-clicks should be handled differently