### PR TITLE
Move every page naming to top nav component

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -16,7 +16,6 @@ export default function AccountsPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Accounts</h2>
         <Button>
           <PlusCircle className="mr-2 h-4 w-4" />
           Link Account

--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -16,7 +16,6 @@ export default function BudgetsPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Budgets</h2>
         <Button>
           <PlusCircle className="mr-2 h-4 w-4" />
           Create Budget

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,7 +9,7 @@
 export default function DashboardPage() {
   return (
     <div>
-      <h1>Dashboard WIP</h1>
+      <h1>WIP</h1>
     </div>
   );
   /*

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -16,7 +16,6 @@ export default function GoalsPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Financial Goals</h2>
         <Button>
           <PlusCircle className="mr-2 h-4 w-4" />
           Create Goal


### PR DESCRIPTION
# 🚀 Remove page headers from UI

## 📖 Context
- Linked Issue: Closes #N/A  
- Simplifies the UI by removing redundant page headers that were duplicating information already shown in the navigation

## 🛠️ What's inside
- Removed heading elements from Accounts, Budgets, and Goals pages
- Maintained action buttons (Link Account, Create Budget, Create Goal)

## ✅ Checklist
- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm ci
npm run dev
# Manually verified each page renders correctly without headers
```

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- This is a purely UI change with no functional impact
- Please verify the pages still look balanced without the headers