### PR TITLE
Add sub-menu to edit/delete specific budget

### DIFF
--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -22,9 +22,10 @@ import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, D
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
-import { PlusCircleIcon } from "lucide-react";
+import { Ellipsis, PlusCircleIcon } from "lucide-react";
 import { deleteTransaction } from "convex/transactions";
 import { Progress } from "~/components/ui/progress";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "~/components/ui/dropdown-menu";
 
 type Budget = Doc<"budgets">;
 
@@ -553,8 +554,30 @@ const BudgetsList = memo(({
                 </div>
 
                 {/* the used percentage (right-aligned, fixed width) */}
-                <div className="shrink-0 w-16 text-right tabular-nums text-sm text-muted-foreground">
+                <div className="shrink-0 flex items-center justify-center w-16 text-right tabular-nums text-sm text-muted-foreground">
                   {pct.toFixed(1)}%
+                  {/* Dropdowns to add edit and delete functionality */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <Ellipsis className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="absolute right-0">
+                    <DropdownMenuItem
+                      onClick={() => handleEditBudget(budget)}
+                      className="cursor-pointer"
+                    >
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleDeleteBudget(budget)}
+                      className="cursor-pointer"
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
                 </div>
               </div>
               <Progress value={pctClamped} />


### PR DESCRIPTION
# 🚀 feat(budgets): add edit and delete functionality to budget items

## 📖 Context
- Enhances user experience by allowing direct management of budget items through contextual dropdown menus

## 🛠️ What's inside
- Added dropdown menu with Edit and Delete options to each budget item
- Implemented Ellipsis icon button to access the dropdown menu
- Connected dropdown actions to existing handler functions

## ✅ Checklist
- [x] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [x] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [x] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm ci
npm run dev
# Manually tested dropdown functionality on budget items
```

## 📸 Proof
The dropdown menu appears when clicking the ellipsis icon next to the budget percentage, providing Edit and Delete options that trigger the appropriate handlers.

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- Focus on the dropdown menu implementation and its integration with existing edit/delete handlers
- Verify that the dropdown positioning works correctly in different viewport sizes