### PR TITLE
fix styling to show red marks when overspent

### DIFF
--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -36,14 +36,9 @@ import {
 } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
 import { Ellipsis, PlusCircleIcon } from "lucide-react";
-import { deleteTransaction } from "convex/transactions";
 import { Progress } from "~/components/ui/progress";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "~/components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "~/components/ui/dropdown-menu";
+import { cn } from "~/lib/utils";
 
 type Budget = Doc<"budgets">;
 
@@ -466,75 +461,71 @@ const BudgetsList = memo(
       [setDialogState, setIsDialogOpen],
     );
 
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">All Budgets</CardTitle>
-          <CardDescription className="text-xs">
-            Track your spending against budget categories
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {budgetList.map((budget) => {
-            const spent = spendByBudget?.[budget._id] ?? 0;
-            const amount = budget.amount ?? 0;
-            const pct = amount > 0 ? (spent / amount) * 100 : 0;
-            const pctClamped = Math.min(Math.max(pct, 0), 100);
-            return (
-              <div
-                key={budget._id}
-                className="flex flex-col gap-2 border-b pb-3 last:border-b-0"
-              >
-                <div className="flex items-center justify-between gap-4">
-                  {/* name, amount, spent */}
-                  <div className="flex min-w-0 flex-col">
-                    <div className="truncate text-sm font-medium">
-                      {budget.name}
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      {formatCurrency(spent)} / {formatCurrency(amount)}
-                    </div>
-                  </div>
-
-                  {/* the used percentage (right-aligned, fixed width) */}
-                  <div className="text-muted-foreground flex w-16 shrink-0 items-center justify-center text-right text-xs tabular-nums">
-                    {pct.toFixed(1)}%
-                    {/* Dropdowns to add edit and delete functionality */}
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon">
-                          <Ellipsis className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="end"
-                        className="absolute right-0"
-                      >
-                        <DropdownMenuItem
-                          onClick={() => handleEditBudget(budget)}
-                          className="cursor-pointer"
-                        >
-                          Edit
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => handleDeleteBudget(budget)}
-                          className="cursor-pointer"
-                        >
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">All Budgets</CardTitle>
+        <CardDescription className="text-xs">Track your spending against budget categories</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {budgetList.map((budget) => {
+          const spent = spendByBudget?.[budget._id] ?? 0;
+          const amount = budget.amount ?? 0;
+          const pct = amount > 0 ? (spent / amount) * 100 : 0;
+          const pctClamped = Math.min(Math.max(pct, 0), 100);
+          const isOverspent = pct >= 100;
+          return (
+            <div key={budget._id} className="flex flex-col gap-2 border-b last:border-b-0 pb-3">
+              <div className="flex items-center justify-between gap-4">
+                {/* name, amount, spent */}
+                <div className="flex min-w-0 flex-col">
+                  <div className={cn("truncate font-medium text-sm", isOverspent && "text-destructive")}>{budget.name}</div>
+                  <div className={cn("text-xs text-muted-foreground", isOverspent && "text-destructive")}>
+                    {formatCurrency(spent)} / {formatCurrency(amount)}
                   </div>
                 </div>
-                <Progress value={pctClamped} />
+
+                {/* the used percentage (right-aligned, fixed width) */}
+                <div className={cn("shrink-0 flex items-center justify-center w-16 text-right tabular-nums text-xs text-muted-foreground", isOverspent && "text-destructive")}> 
+                  {pct.toFixed(1)}%
+                  {/* Dropdowns to add edit and delete functionality */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <Ellipsis className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="absolute right-0">
+                    <DropdownMenuItem
+                      onClick={() => handleEditBudget(budget)}
+                      className="cursor-pointer"
+                    >
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleDeleteBudget(budget)}
+                      className="cursor-pointer"
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                </div>
               </div>
-            );
-          })}
-          {children}
-        </CardContent>
-      </Card>
-    );
-  },
-);
+              <Progress
+                value={pctClamped}
+                indicatorClassName={cn(isOverspent && "bg-destructive")}
+              />
+              {isOverspent && (
+                <div className="text-destructive text-xs">Overspent</div>
+              )}
+            </div>
+          );
+        })}
+        {children}
+      </CardContent>
+    </Card>
+  )
+});
 
 BudgetsList.displayName = "BudgetsList";

--- a/src/components/budget-overview.tsx
+++ b/src/components/budget-overview.tsx
@@ -15,8 +15,9 @@ export function BudgetOverview({ showAll = false }: BudgetOverviewProps) {
   return (
     <div className="space-y-4">
       {budgets.map((budget) => {
-        const percentage = Math.min(100, (budget.spent / budget.limit) * 100);
-        const isOverBudget = budget.spent > budget.limit;
+        const pct = (budget.spent / budget.limit) * 100;
+        const percentage = Math.min(100, Math.max(pct, 0));
+        const isOverBudget = pct >= 100;
 
         return (
           <div key={budget.id} className="space-y-1">
@@ -36,8 +37,12 @@ export function BudgetOverview({ showAll = false }: BudgetOverviewProps) {
             </div>
             <Progress
               value={percentage}
-              className={`h-2 ${isOverBudget ? "bg-red-100" : ""}`}
+              className="h-2"
+              indicatorClassName={isOverBudget ? "bg-destructive" : undefined}
             />
+            {isOverBudget && (
+              <div className="text-destructive text-xs">Overspent</div>
+            )}
           </div>
         );
       })}

--- a/src/components/dashboard/budget-overview.tsx
+++ b/src/components/dashboard/budget-overview.tsx
@@ -37,8 +37,9 @@ function BudgetOverview() {
   return (
     <div className="space-y-4">
       {budgets.map((budget) => {
-        const percentage = Math.min(100, (budget.spent / budget.limit) * 100);
-        const isOverBudget = budget.spent > budget.limit;
+        const pct = (budget.spent / budget.limit) * 100;
+        const percentage = Math.min(100, Math.max(pct, 0));
+        const isOverBudget = pct >= 100;
 
         return (
           <div key={budget.id} className="space-y-1">
@@ -58,8 +59,12 @@ function BudgetOverview() {
             </div>
             <Progress
               value={percentage}
-              className={`h-2 ${isOverBudget ? "bg-red-100" : ""}`}
+              className="h-2"
+              indicatorClassName={isOverBudget ? "bg-destructive" : undefined}
             />
+            {isOverBudget && (
+              <div className="text-destructive text-xs">Overspent</div>
+            )}
           </div>
         );
       })}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -4,12 +4,10 @@ import TopNav from "./top-nav";
 export default function Sidebar({ children }: { children: React.ReactNode }) {
   return (
     <div className="relative flex min-h-dvh flex-col">
-      {/* Floating User Button respecting safe area top */}
-      {/* TODO: replace with top nav containing: user button, current page title, settings button */}
       <TopNav />
 
       {/* Main content */}
-      <div className="px-2 pt-4 pb-24">{children}</div>
+      <div className="pt-4 pb-24">{children}</div>
 
       {/* Bottom navigation */}
       <BottomNav />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
         className,
       )}
       {...props}
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-4", className)}
       {...props}
     />
   );
@@ -75,7 +75,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-4 [.border-t]:pt-6", className)}
       {...props}
     />
   );

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -8,8 +8,11 @@ import { cn } from "~/lib/utils";
 function Progress({
   className,
   value,
+  indicatorClassName,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string;
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -21,7 +24,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn("bg-primary h-full w-full flex-1 transition-all", indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/todo.md
+++ b/todo.md
@@ -75,3 +75,13 @@ So, if I comeback later to this repo, here's what I should do:
 # Back again for the 4th time
 - Fixed migration script where categoryId is still unset
 - Budgets page is now fully working, just missing some basic styling on the metrics part
+
+# Back again for the 5th time
+- Completed the budget page, fixed the font styling issue on metrics part. Something still missing tho:
+  - Card too small, remove some margin / padding
+  - Left and right margin is too big
+  - Overspent on each budget is not implemented
+
+### Working on budgets page
+- [ ] Implement overspent on each budget card
+- [ ] 


### PR DESCRIPTION
# 🚀 TITLE

<!-- e.g. feat(payment): allow splitting invoices -->

## 📖 Context

- Linked Issue: Closes #123
- Why does this matter for the user / business?

## 🛠️ What’s inside

- Short bullet list of _visible_ changes
- Non-obvious refactors

## ✅ Checklist

- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it

```
# commands someone can rerun
npm ci
npm test
npm run e2e
```

## 📸 Proof

<!-- GIF, screenshot, or log snippet -->

## 🔙 Rollback plan

- `git revert <sha>` is clean OR
- feature flagged behind `<flag-name>`

## 🙋‍♂️ Reviewer notes

- Where to start?
- Risky areas?