### PR TITLE
remove old category column and fix api bug

### DIFF
--- a/convex/migrate.ts
+++ b/convex/migrate.ts
@@ -2,8 +2,6 @@ import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import { formatCategoryName } from "~/lib/utils";
 
-
-
 export const backfillCategoriesTable = internalMutation({
   args: {},
   returns: v.object({
@@ -45,7 +43,7 @@ export const backfillCategoriesTable = internalMutation({
           targetBudgetId = await ctx.db.insert("budgets", {
             userId: trx.userId,
             name: categoryName,
-            amount: 100,
+            amount: 0,
           });
           createdCount++;
         }
@@ -67,4 +65,23 @@ export const backfillCategoriesTable = internalMutation({
       throw error;
     }
   },
+});
+
+export const deleteCategoryField = internalMutation({
+  args: {},
+  returns: v.object({
+    success: v.boolean(),
+  }),
+  handler: async (ctx) => {
+    const transactions = await ctx.db.query("transactions").collect();
+
+    console.log(`Starting category field deletion for ${transactions.length} transactions`);
+
+    for (const trx of transactions) {
+      await ctx.db.patch(trx._id, { category: undefined });
+    }
+
+    console.log(`Category field deletion completed`);
+    return { success: true };
+  }
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,7 +9,7 @@ export default defineSchema({
   }).index("by_token_identifier", ["tokenIdentifier"]),
   transactions: defineTable({
     userId: v.id("users"),
-    merchantName: v.optional(v.string()),
+    merchantName: v.string(),
     description: v.optional(v.string()),
     amount: v.number(),
     type: v.union(
@@ -17,8 +17,7 @@ export default defineSchema({
       v.literal("expense"),
       v.literal("investment"),
     ),
-    category: v.optional(v.string()),
-    categoryId: v.optional(v.id("budgets")), // Non-breaking new field, once everything moves here, remove the optional flag.
+    categoryId: v.id("budgets"),
     date: v.string(),
   })
     .index("by_user_date", ["userId", "date"])


### PR DESCRIPTION
# 🚀 Refactor transaction schema to use categoryId instead of category field

## 📖 Context
- This change completes the migration from using string-based categories to using budget IDs for categorization, improving data consistency and enabling better budget tracking.

## 🛠️ What's inside
- Changed default budget amount from 100 to 0 in backfill migration
- Added new `deleteCategoryField` migration to remove the deprecated `category` field
- Updated schema to make `merchantName` required and remove the `category` field
- Modified `categoryId` to be required instead of optional
- Updated transaction mutations to use `categoryId` instead of string-based categories

## ✅ Checklist
- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npx convex run migrate:deleteCategoryField
npx convex dev
# Verified transactions can be created and updated with categoryId
```

## 📸 Proof
All transactions now use the categoryId field for categorization, and the legacy category field has been removed.

## 🔙 Rollback plan
- `git revert <sha>` would require data migration to restore category values

## 🙋‍♂️ Reviewer notes
- This is a breaking change for the API - client code will need to be updated to use categoryId
- The migration should be run before deploying the schema changes