### PR TITLE
fix: category section's state doesn't sync between client and form

### DIFF
--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -185,7 +185,7 @@ function TransactionDialog({
         description: dialogState.transaction.description ?? "",
         amount: dialogState.transaction.amount,
         type: dialogState.transaction.type,
-        categoryId: String(dialogState.transaction.categoryId ?? ""),
+        categoryId: dialogState.transaction.categoryId ?? "",
         date: dialogState.transaction.date,
       });
 
@@ -201,7 +201,7 @@ function TransactionDialog({
         description: "",
         amount: 0,
         type: "expense" as const,
-        categoryId: "",
+        categoryId: getAvailableCategories?.[0]?._id ?? "",
         date: nowIso,
       });
       // Set date-related UI to "now"


### PR DESCRIPTION
# 🚀 Fix transaction form handling and default category selection

## 📖 Context
- Linked Issue: Closes #40
- Improves user experience by fixing a type conversion issue and providing a default category selection when creating new transactions

## 🛠️ What's inside
- Fixed type handling for `categoryId` by removing unnecessary string conversion
- Added default category selection when initializing a new transaction form

## ✅ Checklist
- [x] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm ci
npm run dev
# Created new transactions to verify default category selection works
# Edited existing transactions to verify categoryId is handled correctly
```

## 📸 Proof
When creating a new transaction, the first available category is now pre-selected instead of requiring the user to make a selection.

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- Focus on the transaction dialog form handling in the transactions page
- The changes are minimal but improve the UX significantly