### PR TITLE
fix: date section's default is now 'now' string instead

### DIFF
--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -206,7 +206,7 @@ function TransactionDialog({
       });
       // Set date-related UI to "now"
       setDatePickerDate(now);
-      setDatePickerInputValue(formatDate(nowIso));
+      setDatePickerInputValue("Now");
       setDatePickerMonth(now);
       // Reset category selection; a separate effect will set the first available once categories load
       setCategoryValue(getAvailableCategories?.[0]?._id ?? "");
@@ -523,9 +523,7 @@ function TransactionDialog({
                 // local helper to format date for display without instantly throwing error
                 function formatDateDisplay(date: Date | undefined) {
                   if (!date) return "";
-                  return date.toLocaleDateString("id-ID", {
-                    dateStyle: "medium",
-                  });
+                  return formatDate(date);
                 }
 
                 return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,9 +18,17 @@ const percentageFormatter = new Intl.NumberFormat("id-ID", {
   signDisplay: "exceptZero",
 });
 
-const dateFormatter = new Intl.DateTimeFormat("id-ID", {
-  dateStyle: "medium",
-});
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+const getDateFormatter = (locale = "id-ID") => {
+  if (!dateFormatterCache.has(locale)) {
+    dateFormatterCache.set(
+      locale,
+      new Intl.DateTimeFormat(locale, { dateStyle: "medium" }),
+    );
+  }
+  return dateFormatterCache.get(locale)!;
+};
 
 export const formatCurrency = (value: number): string => {
   return currencyFormatter.format(value);
@@ -30,12 +38,12 @@ export const formatPercentage = (value: number): string => {
   return percentageFormatter.format(value);
 };
 
-export const formatDate = (date: string | Date): string => {
+export const formatDate = (date: string | Date, locale?: string): string => {
   const dateObj = typeof date === "string" ? new Date(date) : date;
 
   if (isNaN(dateObj.getTime())) return "Invalid date";
 
-  return dateFormatter.format(dateObj);
+  return getDateFormatter(locale).format(dateObj);
 };
 
 export const formatCategoryName = (name: string) => {


### PR DESCRIPTION
# 🚀 Improve date formatting with caching and consistent display

## 📖 Context
- Linked Issues: Closes #39
- Improves date formatting consistency across the application
- Enhances performance by implementing a formatter cache

## 🛠️ What's inside
- Added a date formatter cache to avoid recreating formatters
- Changed transaction dialog to display "Now" instead of formatted current date
- Standardized date display format using the shared `formatDate` utility
- Added locale parameter support to `formatDate` function

## ✅ Checklist
- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm ci
npm test
```

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- Focus on the date formatter caching implementation in utils.ts
- Verify the "Now" display in the transaction dialog works as expected