### PR TITLE
feat: transactions are now separated by date

### DIFF
--- a/convex/transactions.ts
+++ b/convex/transactions.ts
@@ -1,6 +1,5 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import { formatCategoryName } from "~/lib/utils";
 
 export const getAllTransactions = query({
   args: {

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,9 +1,9 @@
-"use client";
+"use client"
 
-import * as React from "react";
-import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "~/lib/utils";
+import { cn } from "~/lib/utils"
 
 function Separator({
   className,
@@ -18,11 +18,11 @@ function Separator({
       orientation={orientation}
       className={cn(
         "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
-        className,
+        className
       )}
       {...props}
     />
-  );
+  )
 }
 
-export { Separator };
+export { Separator }


### PR DESCRIPTION
# 🚀 Group transactions by date in the transaction list

## 📖 Context
- Linked Issues: Closes #49
- Improves transaction list readability by organizing entries by date
- Enhances user experience by providing clear temporal context for transactions

## 🛠️ What's inside
- Added date headers (Today, Yesterday, or formatted date) to group transactions
- Implemented transaction grouping logic with `groupTransactionsByDate` helper
- Improved transaction card styling with better shadows and borders
- Removed redundant date display from individual transaction items
- Added `DateHeader` component with separators for visual distinction

## ✅ Checklist
- [x] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [x] Mobile / a11y checked (if UI)
- [x] I have self-reviewed and left comments for reviewers
- [x] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm run dev
# Added, edited, and deleted transactions across multiple dates
# Verified date grouping works correctly for today, yesterday, and older dates
```

## 📸 Proof
![image.png](https://app.graphite.dev/user-attachments/assets/2e0435f1-e194-4c50-9e72-54e3efedd773.png)

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- The main logic is in the new `groupTransactionsByDate` function at the bottom of the transactions page
- Used `useMemo` to optimize the grouping operation and prevent unnecessary recalculations