### PR TITLE
fix: remove bouncy effect in iOS on overscroll

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -165,11 +165,13 @@
 html {
   font-family: var(--font-sans);
   font-size: 14px;
+  overscroll-behavior-y: none;
 }
 
 body {
   letter-spacing: var(--tracking-normal);
   padding-top: env(safe-area-inset-top);
+  overscroll-behavior-y: none;
 }
 
 .hf-hand {


### PR DESCRIPTION
# 🚀 Prevent overscroll bounce on HTML and body elements

## 📖 Context

- Linked Issue: Closes #N/A
- Prevents the bounce/rubber-band effect when scrolling beyond the page boundaries, creating a more app-like experience

## 🛠️ What's inside

- Added `overscroll-behavior: none` to both HTML and body elements
- Maintains existing font and spacing settings

## ✅ Checklist

- [x] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [x] Mobile / a11y checked (if UI)
- [x] I have self-reviewed and left comments for reviewers
- [x] No secrets, API keys or PII committed

## 🧪 How I tested it

```
npm run dev
# Manually tested scrolling behavior on different browsers and devices
```

## 📸 Proof

When scrolling past the boundaries of the page, there is no longer a bounce/rubber-band effect, creating a more contained experience.

## 🔙 Rollback plan

- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes

- This is a simple CSS change that affects the scrolling behavior across the entire application
- Please test on both desktop and mobile browsers to ensure consistent behavior