### PR TITLE
make loading state uniform between routes

### DIFF
--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -1,4 +1,4 @@
-import { PlusCircle } from "lucide-react";
+import { Loader2, PlusCircle } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -37,6 +37,7 @@ function Todo() {
 }
 
 export default function AccountsPage() {
+  return <LoadingState />;
   return <Todo />;
   return (
     <div className="space-y-4">
@@ -120,6 +121,14 @@ export default function AccountsPage() {
           <AccountsOverview showAll={true} />
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin" />
     </div>
   );
 }

--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -34,7 +34,7 @@ import {
   FormMessage,
 } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
-import { Ellipsis, Plus, PlusCircleIcon } from "lucide-react";
+import { Ellipsis, Loader2, Plus, PlusCircleIcon } from "lucide-react";
 import { Progress } from "~/components/ui/progress";
 import {
   DropdownMenu,
@@ -431,7 +431,11 @@ function BudgetDialog({
 }
 
 function LoadingState() {
-  return <div>Loading...</div>;
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin" />
+    </div>
+  );
 }
 
 function EmptyState({

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   SearchIcon,
   FilterIcon,
+  Loader2,
 } from "lucide-react";
 import {
   Card,
@@ -683,8 +684,8 @@ function TransactionDialog({
 function LoadingState() {
   return (
     <>
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-dvh w-full" />
+      <div className="flex flex-col items-center justify-center">
+        <Loader2 className="h-10 w-10 animate-spin" />
       </div>
     </>
   );


### PR DESCRIPTION
# 🚀 Enhance loading states with animated spinner

## 📖 Context
- Linked Issue: Closes #N/A
- Improves user experience by providing a consistent loading animation across the application

## 🛠️ What's inside
- Added animated spinner loading state to Accounts page
- Updated Budgets page loading state with animated spinner
- Replaced skeleton loading in Transactions page with animated spinner
- Imported Loader2 icon from lucide-react where needed

## ✅ Checklist
- [ ] Code compiles & lint passes
- [ ] Unit / integration tests added or updated
- [ ] Docs updated (README, ADR, storybook, etc.)
- [ ] Mobile / a11y checked (if UI)
- [ ] I have self-reviewed and left comments for reviewers
- [ ] No secrets, API keys or PII committed

## 🧪 How I tested it
```bash
npm ci
npm run dev
```

## 📸 Proof
The loading state now shows a centered, spinning loader icon instead of text or skeleton loaders.

## 🔙 Rollback plan
- `git revert <sha>` is clean

## 🙋‍♂️ Reviewer notes
- This is a UI-only change affecting loading states
- The Accounts page is now set to always show the loading state (temporary for testing)